### PR TITLE
Update homeowner Step 6 to Review & Payment with required Stripe verification

### DIFF
--- a/client/src/components/ServiceIntakeModal.jsx
+++ b/client/src/components/ServiceIntakeModal.jsx
@@ -591,33 +591,25 @@ export default function ServiceIntakeModal({ open, onClose, defaultCity, default
         if (estimateFee.eligible) {
           return (
             <div className="space-y-5">
-              <h3 className="text-xl font-bold text-slate-900">$75 Service Request Fee</h3>
+              <h3 className="text-xl font-bold text-slate-900">Review &amp; Payment</h3>
 
               {/* Fee explanation (approved text) */}
               <div className="rounded-xl border border-emerald-300 bg-emerald-50 p-5 space-y-3">
-                <div className="flex items-center gap-3">
-                  <span className="text-3xl font-extrabold text-emerald-700">$75</span>
-                  <p className="font-semibold text-slate-900">Service Request Fee</p>
-                </div>
-                <p className="font-semibold text-slate-800">Your $75 Service Request Fee includes:</p>
+                <p className="font-semibold text-slate-900">Your $75 Service Request Fee Includes:</p>
                 <ul className="space-y-2 text-sm text-slate-700">
-                  <li className="flex items-start">
-                    <span className="mr-2">•</span>
-                    <span>Professional project estimate</span>
-                  </li>
-                  <li className="flex items-start">
-                    <span className="mr-2">•</span>
-                    <span>Matching with verified local professionals</span>
-                  </li>
-                  <li className="flex items-start">
-                    <span className="mr-2">•</span>
-                    <span>Priority review of your request</span>
-                  </li>
-                  <li className="flex items-start">
-                    <span className="mr-2">•</span>
-                    <span>A qualified professional will contact you within 24 hours</span>
-                  </li>
+                  <li>• Professional project estimate from verified local professionals</li>
+                  <li>• Priority review of your project</li>
+                  <li>• Matching with the most qualified local professional</li>
+                  <li>• A professional will contact you within 24 hours or less</li>
+                  <li>• You&apos;ll receive a detailed quote before any work begins</li>
+                  <li>• No work will begin without your approval</li>
+                  <li>• Materials (if needed) will be itemized separately in the contractor&apos;s final quote</li>
                 </ul>
+
+                <p className="text-base font-bold text-slate-900">Service Request Fee: $75</p>
+                <p className="text-sm text-slate-700">
+                  This one-time fee covers the review and processing of your request, the preparation of a professional estimate, and matching you with a qualified local professional. It is not a payment for the repair or construction work itself.
+                </p>
               </div>
 
               {/* Contact info collected here so it can be saved before Stripe redirect */}
@@ -673,7 +665,7 @@ export default function ServiceIntakeModal({ open, onClose, defaultCity, default
                   className="mt-1 h-5 w-5 text-brand border-slate-300 rounded focus:ring-brand"
                 />
                 <span className="text-slate-700 text-sm">
-                  I understand that a $75 Service Request Fee is required before my request is submitted and that no work will begin without my approval.
+                  I understand that a $75 Service Request Fee is required before my request can be submitted.
                 </span>
               </label>
               {errors.termsAccepted && <p className="text-red-600 text-sm">{errors.termsAccepted}</p>}
@@ -687,7 +679,7 @@ export default function ServiceIntakeModal({ open, onClose, defaultCity, default
                 aria-label="Pay $75 service request fee via Stripe secure checkout"
                 className="btn-primary w-full py-3 disabled:opacity-50 disabled:cursor-not-allowed"
               >
-                {isSubmitting ? 'Preparing checkout...' : 'Pay $75 and Submit Request →'}
+                {isSubmitting ? 'Preparing checkout...' : 'Continue to Secure Payment'}
               </button>
 
               <p className="text-xs text-center text-slate-500">

--- a/server/config/pricing.js
+++ b/server/config/pricing.js
@@ -3,13 +3,13 @@
  * Defines pricing strategies and conversion rates for different countries
  */
 
-// Homeowner request/matching fee — free (no upfront cost)
-const HOMEOWNER_REQUEST_PRICE = 0;
-const HOMEOWNER_REQUEST_PRICE_CENTS = 0;
+// Homeowner request/matching fee
+const HOMEOWNER_REQUEST_PRICE = 75;
+const HOMEOWNER_REQUEST_PRICE_CENTS = 7500;
 
 // Base pricing in USD (US market)
 const BASE_PRICING = {
-  // Homeowner request / matching fee — free, no upfront cost
+  // Homeowner request / matching fee
   homeownerRequest: HOMEOWNER_REQUEST_PRICE,
 
   // Backward-compatible alias for legacy early-access consumers

--- a/server/routes/stripe.js
+++ b/server/routes/stripe.js
@@ -7,6 +7,7 @@ const Pro = require('../models/Pro');
 const JobRequest = require('../models/JobRequest');
 const Referral = require('../models/Referral');
 const EarlyAccessSpots = require('../models/EarlyAccessSpots');
+const { HOMEOWNER_REQUEST_PRICE_CENTS } = require('../config/pricing');
 const { applyReferralFreeMonth, hasExistingReward } = require('../services/applyReferralFreeMonth');
 const { sendSms } = require('../utils/twilio');
 const { notify: ownerNotify } = require('../services/ownerNotificationService');
@@ -165,14 +166,113 @@ router.post('/create-setup-intent', async (req, res) => {
   }
 });
 
-// Homeowner quote requests are free — this endpoint is kept for backwards compatibility
-// but no longer creates a Stripe checkout session
+// Create checkout session for homeowner request fee
 router.post('/homeowner-checkout', async (req, res) => {
-  return res.json({
-    success: true,
-    free: true,
-    message: 'Homeowner quote requests are completely free. No payment required.'
-  });
+  try {
+    if (!stripe) {
+      return res.status(500).json({
+        success: false,
+        message: 'Stripe is not configured on the server.'
+      });
+    }
+
+    if (!HOMEOWNER_REQUEST_PRICE_CENTS || HOMEOWNER_REQUEST_PRICE_CENTS <= 0) {
+      return res.status(500).json({
+        success: false,
+        message: 'Homeowner request fee is not configured.'
+      });
+    }
+
+    const clientUrl = process.env.YOUR_DOMAIN || process.env.CLIENT_URL || 'https://www.fixloapp.com';
+    const { returnPath } = req.body || {};
+    const safePath = typeof returnPath === 'string' && returnPath.startsWith('/') ? returnPath : '/request';
+    const returnUrl = new URL(safePath, clientUrl);
+    const cancelUrl = new URL(safePath, clientUrl);
+
+    returnUrl.searchParams.set('checkout', 'success');
+    returnUrl.searchParams.set('session_id', '{CHECKOUT_SESSION_ID}');
+    returnUrl.searchParams.set('payment_status', 'success');
+
+    cancelUrl.searchParams.set('checkout', 'cancel');
+    cancelUrl.searchParams.set('payment_status', 'cancelled');
+
+    const session = await stripe.checkout.sessions.create({
+      mode: 'payment',
+      payment_method_types: ['card'],
+      line_items: [
+        {
+          price_data: {
+            currency: 'usd',
+            product_data: {
+              name: 'Fixlo Service Request Fee',
+              description: 'One-time service request review and matching fee'
+            },
+            unit_amount: HOMEOWNER_REQUEST_PRICE_CENTS
+          },
+          quantity: 1
+        }
+      ],
+      success_url: returnUrl.toString(),
+      cancel_url: cancelUrl.toString(),
+      metadata: {
+        kind: 'homeowner_request_fee',
+        amountCents: String(HOMEOWNER_REQUEST_PRICE_CENTS),
+        source: 'request_flow'
+      }
+    });
+
+    return res.json({
+      success: true,
+      sessionId: session.id,
+      sessionUrl: session.url
+    });
+  } catch (error) {
+    console.error('❌ Error creating homeowner checkout session:', error.message);
+    return res.status(500).json({
+      success: false,
+      message: 'Unable to create secure payment session.'
+    });
+  }
+});
+
+router.get('/homeowner-checkout/verify', async (req, res) => {
+  try {
+    if (!stripe) {
+      return res.status(500).json({
+        verified: false,
+        message: 'Stripe is not configured on the server.'
+      });
+    }
+
+    const sessionId = String(req.query.session_id || '').trim();
+    if (!sessionId) {
+      return res.status(400).json({
+        verified: false,
+        message: 'Missing session_id'
+      });
+    }
+
+    const session = await stripe.checkout.sessions.retrieve(sessionId);
+    const verified =
+      session.mode === 'payment' &&
+      session.payment_status === 'paid' &&
+      session.amount_total === HOMEOWNER_REQUEST_PRICE_CENTS &&
+      session.metadata?.kind === 'homeowner_request_fee';
+
+    return res.json({
+      verified,
+      sessionId,
+      paymentStatus: session.payment_status,
+      amountTotal: session.amount_total,
+      currency: session.currency
+    });
+  } catch (error) {
+    console.error('❌ Error verifying homeowner checkout session:', error.message);
+    return res.status(500).json({
+      verified: false,
+      message: 'Unable to verify payment session.'
+    });
+  }
 });
 
 // Create checkout session for subscription with 30-day free trial


### PR DESCRIPTION
## Summary
- Renames Step 6 section to **Review & Payment** in homeowner `/request` flow
- Replaces Step 6 copy with the requested $75 fee checklist and explanation
- Replaces Step 6 CTA with **Continue to Secure Payment**
- Creates Stripe Checkout session and redirects user securely
- Verifies Stripe checkout session on return and moves user to Step 7
- Blocks final request submission unless payment is verified by backend

## Backend enforcement
- Adds Stripe homeowner checkout session endpoint
- Adds Stripe session verification endpoint
- Enforces verified Stripe payment in `/api/requests` when required
- Updates homeowner request pricing constants to $75 / 7500 cents

## Validation
- Frontend build passed locally (`npm run build`)