### PR TITLE
Add $120 handyman booking with Stripe

### DIFF
--- a/client/src/components/HandymanBookingForm.jsx
+++ b/client/src/components/HandymanBookingForm.jsx
@@ -1,0 +1,173 @@
+import React, { useEffect, useState } from 'react';
+import { useSearchParams } from 'react-router-dom';
+import { API_BASE } from '../utils/config';
+import { csrfFetch } from '../utils/csrf';
+
+const INITIAL = {
+  fullName: '',
+  email: '',
+  phone: '',
+  address: '',
+  city: '',
+  state: '',
+  zipCode: '',
+  preferredDate: '',
+  preferredTime: '',
+  details: '',
+  smsConsent: false,
+  pricingAccepted: false
+};
+
+export default function HandymanBookingForm() {
+  const [searchParams] = useSearchParams();
+  const [form, setForm] = useState(INITIAL);
+  const [loading, setLoading] = useState(false);
+  const [message, setMessage] = useState('');
+  const [paymentComplete, setPaymentComplete] = useState(false);
+
+  useEffect(() => {
+    const sessionId = searchParams.get('session_id');
+    const checkout = searchParams.get('checkout');
+    if (checkout !== 'success' || !sessionId) return;
+
+    let cancelled = false;
+    fetch(`${API_BASE}/api/subscribe/handyman-checkout/verify?session_id=${encodeURIComponent(sessionId)}`, {
+      credentials: 'include'
+    })
+      .then(async (res) => ({ ok: res.ok, body: await res.json().catch(() => ({})) }))
+      .then(({ ok, body }) => {
+        if (cancelled) return;
+        if (ok && body.verified) {
+          setPaymentComplete(true);
+          setMessage('Payment received. Your handyman request is confirmed and Fixlo will contact you with scheduling details.');
+        } else {
+          setMessage(body.message || 'We could not verify the payment. Please contact Fixlo support.');
+        }
+      })
+      .catch(() => {
+        if (!cancelled) setMessage('We could not verify the payment. Please contact Fixlo support.');
+      });
+
+    return () => { cancelled = true; };
+  }, [searchParams]);
+
+  const update = (event) => {
+    const { name, value, type, checked } = event.target;
+    setForm((current) => ({ ...current, [name]: type === 'checkbox' ? checked : value }));
+  };
+
+  const submit = async (event) => {
+    event.preventDefault();
+    setMessage('');
+
+    if (!form.pricingAccepted) {
+      setMessage('Please confirm the $120 hourly labor rate and materials policy.');
+      return;
+    }
+    if (form.details.trim().length < 20) {
+      setMessage('Please provide at least 20 characters describing the work.');
+      return;
+    }
+
+    setLoading(true);
+    try {
+      const response = await csrfFetch(`${API_BASE}/api/subscribe/handyman-checkout`, {
+        method: 'POST',
+        body: JSON.stringify(form)
+      });
+      const payload = await response.json().catch(() => ({}));
+      if (!response.ok || !payload.url) {
+        throw new Error(payload.error || 'Unable to start secure checkout.');
+      }
+      window.location.assign(payload.url);
+    } catch (error) {
+      setMessage(error.message || 'Unable to start secure checkout.');
+      setLoading(false);
+    }
+  };
+
+  if (paymentComplete) {
+    return (
+      <div className="mx-auto max-w-2xl rounded-3xl border border-amber-300 bg-white p-8 text-center shadow-xl">
+        <div className="mx-auto flex h-16 w-16 items-center justify-center rounded-full bg-amber-400 text-3xl">✓</div>
+        <h1 className="mt-5 text-3xl font-black text-black">Handyman booked</h1>
+        <p className="mt-3 text-slate-700">{message}</p>
+        <p className="mt-5 text-sm text-slate-500">The $120 checkout covers the first labor hour. Additional labor and materials are billed separately with your approval.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="mx-auto max-w-4xl overflow-hidden rounded-3xl border border-amber-300 bg-white shadow-2xl">
+      <div className="bg-black px-6 py-7 text-white md:px-10">
+        <p className="text-sm font-bold uppercase tracking-[0.25em] text-amber-400">Direct handyman booking</p>
+        <h1 className="mt-2 text-3xl font-black md:text-4xl">Get a Handyman</h1>
+        <p className="mt-3 max-w-2xl text-slate-300">Tell us what you need, confirm the address, and securely reserve the first hour through Stripe.</p>
+      </div>
+
+      <form onSubmit={submit} className="grid gap-5 p-6 md:grid-cols-2 md:p-10">
+        <label className="block text-sm font-bold text-slate-800">Full name
+          <input required name="fullName" value={form.fullName} onChange={update} className="mt-2 w-full rounded-xl border border-slate-300 px-4 py-3" />
+        </label>
+        <label className="block text-sm font-bold text-slate-800">Email
+          <input required type="email" name="email" value={form.email} onChange={update} className="mt-2 w-full rounded-xl border border-slate-300 px-4 py-3" />
+        </label>
+        <label className="block text-sm font-bold text-slate-800">Phone
+          <input required name="phone" value={form.phone} onChange={update} placeholder="(555) 555-5555" className="mt-2 w-full rounded-xl border border-slate-300 px-4 py-3" />
+        </label>
+        <label className="block text-sm font-bold text-slate-800">Street address
+          <input required name="address" value={form.address} onChange={update} className="mt-2 w-full rounded-xl border border-slate-300 px-4 py-3" />
+        </label>
+        <label className="block text-sm font-bold text-slate-800">City
+          <input required name="city" value={form.city} onChange={update} className="mt-2 w-full rounded-xl border border-slate-300 px-4 py-3" />
+        </label>
+        <div className="grid grid-cols-2 gap-3">
+          <label className="block text-sm font-bold text-slate-800">State
+            <input required name="state" value={form.state} onChange={update} maxLength="2" className="mt-2 w-full rounded-xl border border-slate-300 px-4 py-3 uppercase" />
+          </label>
+          <label className="block text-sm font-bold text-slate-800">ZIP code
+            <input required name="zipCode" value={form.zipCode} onChange={update} className="mt-2 w-full rounded-xl border border-slate-300 px-4 py-3" />
+          </label>
+        </div>
+        <label className="block text-sm font-bold text-slate-800">Preferred date
+          <div className="mt-2 flex w-full min-w-0 rounded-xl border border-slate-300 px-4 py-3">
+            <input type="date" name="preferredDate" value={form.preferredDate} onChange={update} className="block w-full min-w-0 border-0 bg-transparent p-0" />
+          </div>
+        </label>
+        <label className="block text-sm font-bold text-slate-800">Preferred time
+          <select name="preferredTime" value={form.preferredTime} onChange={update} className="mt-2 w-full rounded-xl border border-slate-300 px-4 py-3">
+            <option value="">Select a time</option>
+            <option>Morning</option>
+            <option>Afternoon</option>
+            <option>Evening</option>
+            <option>Flexible</option>
+          </select>
+        </label>
+        <label className="block text-sm font-bold text-slate-800 md:col-span-2">Describe the work
+          <textarea required name="details" value={form.details} onChange={update} rows="5" maxLength="1000" placeholder="Describe the repairs, installation, measurements, access details, and anything the handyman should know." className="mt-2 w-full rounded-xl border border-slate-300 px-4 py-3" />
+        </label>
+
+        <div className="rounded-2xl border border-amber-300 bg-amber-50 p-5 md:col-span-2">
+          <p className="text-xl font-black text-black">$120 per labor hour + materials</p>
+          <p className="mt-2 text-sm text-slate-700">Stripe checkout charges $120 to reserve and cover the first labor hour. Additional time is billed at $120 per hour. Materials and approved purchases are additional. Scheduling is confirmed after payment and availability review.</p>
+        </div>
+
+        <label className="flex items-start gap-3 text-sm text-slate-700 md:col-span-2">
+          <input required type="checkbox" name="pricingAccepted" checked={form.pricingAccepted} onChange={update} className="mt-1" />
+          <span>I understand and accept the $120 hourly labor rate, the first-hour Stripe charge, and that materials and additional labor are charged separately.</span>
+        </label>
+        <label className="flex items-start gap-3 text-sm text-slate-700 md:col-span-2">
+          <input type="checkbox" name="smsConsent" checked={form.smsConsent} onChange={update} className="mt-1" />
+          <span>I agree to receive SMS updates about this booking. Message and data rates may apply. Reply STOP to unsubscribe.</span>
+        </label>
+
+        {message && <div className="rounded-xl border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700 md:col-span-2">{message}</div>}
+
+        <button disabled={loading} className="rounded-xl bg-amber-400 px-6 py-4 text-lg font-black text-black transition hover:bg-amber-300 disabled:cursor-not-allowed disabled:opacity-60 md:col-span-2">
+          {loading ? 'Opening secure checkout…' : 'Reserve a Handyman — Pay $120'}
+        </button>
+        <p className="text-center text-xs text-slate-500 md:col-span-2">Secure payment processed by Stripe.</p>
+      </form>
+    </div>
+  );
+}

--- a/client/src/components/HeroSection.jsx
+++ b/client/src/components/HeroSection.jsx
@@ -72,6 +72,13 @@ export default function HeroSection({ headingTag = 'h2' }) {
             >
               Request a Service <span aria-hidden="true" className="text-3xl leading-none">→</span>
             </button>
+            <button
+              onClick={() => navigate('/request?mode=handyman')}
+              className="mt-3 flex w-full items-center justify-center gap-3 rounded-xl border-2 border-black bg-black px-6 py-4 text-lg font-black text-white transition hover:bg-slate-800 focus:outline-none focus:ring-4 focus:ring-amber-300/40"
+            >
+              Get a Handyman <span aria-hidden="true">🔨</span>
+            </button>
+            <p className="mt-3 text-xs font-semibold text-slate-500">$120/hour labor + materials. First hour reserved through Stripe.</p>
             <p className="mt-4 text-sm text-slate-600">▣ &nbsp; Secure. Private. Easy.</p>
           </div>
         </div>

--- a/client/src/routes/RequestPage.jsx
+++ b/client/src/routes/RequestPage.jsx
@@ -1,37 +1,26 @@
 import React, { useEffect, useState } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import ServiceIntakeModal from '../components/ServiceIntakeModal';
+import HandymanBookingForm from '../components/HandymanBookingForm';
 import HelmetSEO from '../seo/HelmetSEO';
 import { API_BASE } from '../utils/config';
 
 const FORM_SESSION_KEY = 'fixlo_service_request_draft';
 
-/**
- * RequestPage - Full-page service request form for ad campaigns
- *
- * Supports query parameters:
- * - city: Pre-fills the city field (e.g., charlotte-nc)
- * - service: Pre-fills the service type (e.g., plumbing)
- * - payment: 'success' or 'cancelled' — returned by Stripe after estimate-fee checkout
- *
- * Examples:
- * - /request
- * - /request?city=charlotte-nc
- * - /request?city=charlotte-nc&service=plumbing
- * - /request?payment=success&leadId=abc123
- * - /request?payment=cancelled&leadId=abc123
- */
 export default function RequestPage() {
   const [searchParams] = useSearchParams();
+  const handymanMode = searchParams.get('mode') === 'handyman';
   const [city, setCity] = useState('');
   const [service, setService] = useState('');
   const [heading, setHeading] = useState('Home Service Request');
-  const [paymentStatus, setPaymentStatus] = useState(null); // 'success' | 'cancelled' | null
+  const [paymentStatus, setPaymentStatus] = useState(null);
   const [paymentSessionId, setPaymentSessionId] = useState('');
   const [restoredFormData, setRestoredFormData] = useState(null);
   const [paymentMessage, setPaymentMessage] = useState('');
 
   useEffect(() => {
+    if (handymanMode) return undefined;
+
     let cancelled = false;
 
     const restoreDraft = () => {
@@ -88,33 +77,39 @@ export default function RequestPage() {
 
     handlePaymentReturn();
 
-    // Extract and process query parameters
     const cityParam = searchParams.get('city');
     const serviceParam = searchParams.get('service');
 
     if (cityParam) {
-      // Extract city name without state suffix (e.g., "charlotte-nc" -> "charlotte")
       const cityName = cityParam.split('-')[0];
       const formattedCity = cityName.charAt(0).toUpperCase() + cityName.slice(1);
-
-      // Pass just the city name to the modal
       setCity(cityName);
       setHeading(`${formattedCity} Home Service Request`);
     }
 
-    if (serviceParam) {
-      setService(serviceParam);
-    }
+    if (serviceParam) setService(serviceParam);
 
     return () => {
       cancelled = true;
     };
-  }, [searchParams]);
+  }, [searchParams, handymanMode]);
 
-  // Page never closes the modal - it's the main content
-  const handleClose = () => {
-    // No-op: This is a dedicated page, not a modal overlay
-  };
+  if (handymanMode) {
+    return (
+      <>
+        <HelmetSEO
+          title="Book a Handyman | Fixlo"
+          description="Book a Fixlo handyman at $120 per labor hour plus materials and securely reserve the first hour through Stripe."
+          canonicalPathname="/request"
+        />
+        <div className="min-h-screen bg-slate-100 px-4 py-10 md:py-16">
+          <HandymanBookingForm />
+        </div>
+      </>
+    );
+  }
+
+  const handleClose = () => {};
 
   return (
     <>
@@ -124,7 +119,6 @@ export default function RequestPage() {
         canonicalPathname="/request"
       />
 
-      {/* Full-page wrapper with custom heading */}
       <div className="min-h-screen bg-slate-50 py-8">
         <div className="container-xl">
           {paymentStatus === 'success' && (

--- a/server/routes/subscribe.js
+++ b/server/routes/subscribe.js
@@ -1,43 +1,209 @@
 // server/routes/subscribe.js
 const express = require("express");
 const router = express.Router();
+const mongoose = require('mongoose');
+const JobRequest = require('../models/JobRequest');
+const { routeLead } = require('../services/leadAssignmentService');
+const { notifyOwnerForLead } = require('../services/ownerLeadNotificationService');
+
+const HANDYMAN_FIRST_HOUR_CENTS = 12000;
+const HANDYMAN_CHECKOUT_KIND = 'handyman_first_hour';
 
 let stripe = null;
 try {
   if (process.env.STRIPE_SECRET_KEY) {
-    stripe = require("stripe")(process.env.STRIPE_SECRET_KEY);
+    stripe = require("stripe")(process.env.STRIPE_SECRET_KEY, { apiVersion: '2023-10-16' });
   }
 } catch (e) {
   console.error("Stripe init error:", e.message);
 }
 
+function normalizeUSPhone(value = '') {
+  const digits = String(value).replace(/\D/g, '');
+  if (digits.length === 10) return `+1${digits}`;
+  if (digits.length === 11 && digits.startsWith('1')) return `+${digits}`;
+  return null;
+}
+
+function clean(value, max = 1000) {
+  return String(value || '').trim().slice(0, max);
+}
+
+/**
+ * POST /api/subscribe/handyman-checkout
+ * Creates a pending handyman request and a $120 Stripe Checkout session.
+ * The $120 payment covers the first labor hour. Materials and later hours are separate.
+ */
+router.post('/handyman-checkout', async (req, res) => {
+  try {
+    if (!stripe) return res.status(503).json({ error: 'Stripe is not configured.' });
+    if (mongoose.connection.readyState !== 1) {
+      return res.status(503).json({ error: 'Booking is temporarily unavailable. Please try again shortly.' });
+    }
+
+    const {
+      fullName, email, phone, address, city, state, zipCode,
+      preferredDate, preferredTime, details, smsConsent, pricingAccepted
+    } = req.body || {};
+
+    const normalizedPhone = normalizeUSPhone(phone);
+    const description = clean(details, 1000);
+    const normalizedEmail = clean(email, 200).toLowerCase();
+
+    if (!clean(fullName, 100) || !normalizedEmail || !normalizedPhone || !clean(address, 200) || !clean(city, 100) || !clean(state, 2) || !clean(zipCode, 12)) {
+      return res.status(400).json({ error: 'Name, email, phone, and complete service address are required.' });
+    }
+    if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(normalizedEmail)) {
+      return res.status(400).json({ error: 'Please enter a valid email address.' });
+    }
+    if (description.length < 20) {
+      return res.status(400).json({ error: 'Please provide at least 20 characters describing the work.' });
+    }
+    if (pricingAccepted !== true) {
+      return res.status(400).json({ error: 'The $120 hourly rate and materials policy must be accepted.' });
+    }
+
+    const requestId = `handyman_${Date.now()}_${Math.random().toString(36).slice(2, 9)}`;
+    const schedule = [clean(preferredDate, 20), clean(preferredTime, 40)].filter(Boolean).join(' — ');
+
+    const job = await JobRequest.create({
+      requestId,
+      trade: 'general repairs',
+      name: clean(fullName, 100),
+      email: normalizedEmail,
+      phone: normalizedPhone,
+      address: clean(address, 200),
+      city: clean(city, 100),
+      state: clean(state, 2).toUpperCase(),
+      zip: clean(zipCode, 12),
+      description,
+      preferredTime: schedule,
+      status: 'pending',
+      paymentProvider: 'stripe',
+      paymentStatus: 'none',
+      laborCost: 120,
+      materialsCost: 0,
+      totalCost: 120,
+      visitFee: 0,
+      termsAccepted: true,
+      termsAcceptedAt: new Date(),
+      pricingAcceptance: true,
+      pricingAcceptanceAt: new Date(),
+      smsConsent: Boolean(smsConsent),
+      smsConsentAt: smsConsent ? new Date() : null
+    });
+
+    const clientUrl = process.env.CLIENT_URL || process.env.YOUR_DOMAIN || 'https://www.fixloapp.com';
+    const session = await stripe.checkout.sessions.create({
+      mode: 'payment',
+      payment_method_types: ['card'],
+      customer_email: normalizedEmail,
+      line_items: [{
+        price_data: {
+          currency: 'usd',
+          unit_amount: HANDYMAN_FIRST_HOUR_CENTS,
+          product_data: {
+            name: 'Fixlo Handyman — First Labor Hour',
+            description: '$120 covers the first labor hour. Additional labor is $120/hour and materials are billed separately with approval.'
+          }
+        },
+        quantity: 1
+      }],
+      success_url: `${clientUrl}/request?mode=handyman&checkout=success&session_id={CHECKOUT_SESSION_ID}`,
+      cancel_url: `${clientUrl}/request?mode=handyman&checkout=cancelled`,
+      metadata: {
+        kind: HANDYMAN_CHECKOUT_KIND,
+        jobRequestId: String(job._id),
+        requestId,
+        hourlyRateCents: String(HANDYMAN_FIRST_HOUR_CENTS)
+      }
+    });
+
+    job.stripeCheckoutSessionId = session.id;
+    await job.save();
+
+    return res.json({ success: true, url: session.url, sessionId: session.id, requestId });
+  } catch (err) {
+    console.error('Handyman checkout error:', err.message);
+    return res.status(500).json({ error: 'Unable to create the secure handyman checkout.' });
+  }
+});
+
+/**
+ * GET /api/subscribe/handyman-checkout/verify?session_id=...
+ * Verifies payment, marks the request captured, and routes it once.
+ */
+router.get('/handyman-checkout/verify', async (req, res) => {
+  try {
+    if (!stripe) return res.status(503).json({ verified: false, message: 'Stripe is not configured.' });
+    if (mongoose.connection.readyState !== 1) {
+      return res.status(503).json({ verified: false, message: 'Booking verification is temporarily unavailable.' });
+    }
+
+    const sessionId = clean(req.query.session_id, 255);
+    if (!sessionId) return res.status(400).json({ verified: false, message: 'Missing payment session.' });
+
+    const session = await stripe.checkout.sessions.retrieve(sessionId);
+    const verified = session.mode === 'payment'
+      && session.payment_status === 'paid'
+      && Number(session.amount_total) === HANDYMAN_FIRST_HOUR_CENTS
+      && session.metadata?.kind === HANDYMAN_CHECKOUT_KIND;
+
+    if (!verified) {
+      return res.status(402).json({ verified: false, message: 'The $120 payment has not been completed.' });
+    }
+
+    const job = await JobRequest.findOne({ stripeCheckoutSessionId: sessionId });
+    if (!job) return res.status(404).json({ verified: false, message: 'Handyman booking was not found.' });
+
+    const newlyCaptured = job.paymentStatus !== 'captured';
+    if (newlyCaptured) {
+      job.paymentStatus = 'captured';
+      job.paymentCapturedAt = new Date();
+      job.paidAt = new Date();
+      job.stripePaymentIntentId = typeof session.payment_intent === 'string' ? session.payment_intent : '';
+      await job.save();
+
+      try {
+        await notifyOwnerForLead(job, { stage: 'paid', amountPaidCents: HANDYMAN_FIRST_HOUR_CENTS });
+      } catch (notifyError) {
+        console.error('Handyman owner notification failed:', notifyError.message);
+      }
+      try {
+        await routeLead(job._id);
+      } catch (routeError) {
+        console.error('Handyman routing failed:', routeError.message);
+      }
+    }
+
+    return res.json({
+      verified: true,
+      requestId: job.requestId,
+      amountPaidCents: HANDYMAN_FIRST_HOUR_CENTS,
+      hourlyRateCents: HANDYMAN_FIRST_HOUR_CENTS,
+      materialsAdditional: true
+    });
+  } catch (err) {
+    console.error('Handyman checkout verification error:', err.message);
+    return res.status(500).json({ verified: false, message: 'Unable to verify the payment session.' });
+  }
+});
+
 /**
  * POST /api/subscribe/checkout
- * Body: { email, priceId }   // priceId optional if you set it in env
- * Returns: { url, sessionId }
+ * Body: { email, priceId }
  */
 router.post("/checkout", async (req, res) => {
   try {
-    if (!stripe) {
-      return res.status(503).json({ error: "Stripe is not configured" });
-    }
+    if (!stripe) return res.status(503).json({ error: "Stripe is not configured" });
 
     const { email, priceId } = req.body || {};
     if (!email) return res.status(400).json({ error: "email is required" });
 
-    // Prefer explicit priceId from request; fall back to env
-    const PRICE_ID =
-      priceId ||
-      process.env.STRIPE_FIRST_MONTH_PRICE_ID ||
-      process.env.STRIPE_MONTHLY_PRICE_ID ||
-      process.env.STRIPE_PRICE_ID;
-
-    if (!PRICE_ID) {
-      return res.status(500).json({ error: "No Stripe priceId configured" });
-    }
+    const PRICE_ID = priceId || process.env.STRIPE_FIRST_MONTH_PRICE_ID || process.env.STRIPE_MONTHLY_PRICE_ID || process.env.STRIPE_PRICE_ID;
+    if (!PRICE_ID) return res.status(500).json({ error: "No Stripe priceId configured" });
 
     const clientUrl = process.env.CLIENT_URL || "https://www.fixloapp.com";
-
     const session = await stripe.checkout.sessions.create({
       mode: "subscription",
       payment_method_types: ["card"],
@@ -45,7 +211,7 @@ router.post("/checkout", async (req, res) => {
       customer_email: email,
       success_url: `${clientUrl}/payment-success.html?session_id={CHECKOUT_SESSION_ID}`,
       cancel_url: `${clientUrl}/payment-cancel.html`,
-      metadata: { source: "pro-signup", email, ts: new Date().toISOString() },
+      metadata: { source: "pro-signup", email, ts: new Date().toISOString() }
     });
 
     return res.json({ url: session.url, sessionId: session.id });
@@ -55,17 +221,10 @@ router.post("/checkout", async (req, res) => {
   }
 });
 
-// Keep the legacy endpoint for backward compatibility
 router.post('/', (req, res) => {
   const { name, email } = req.body;
-
-  if (!name || !email) {
-    return res.status(400).json({ success: false, message: 'Name and email are required' });
-  }
-
-  // Example: Store or forward to CRM/mailing list (stub only)
+  if (!name || !email) return res.status(400).json({ success: false, message: 'Name and email are required' });
   console.log(`📩 New subscription: ${name} <${email}>`);
-
   res.json({ success: true, message: 'Subscription received successfully' });
 });
 


### PR DESCRIPTION
Adds a direct homeowner handyman booking flow without changing the existing general service-request process.

What it adds:
- New “Get a Handyman” button on the homepage
- Dedicated booking form for customer details, full address, preferred date/time, and work description
- Clear pricing acceptance: $120 per labor hour plus materials
- Stripe Checkout charges $120 for the first labor hour
- Secure payment verification after Stripe redirects back to Fixlo
- Paid request is stored as a JobRequest, owner is notified, and existing lead routing is triggered once
- SMS consent remains optional and unchecked by default

Files changed:
- client/src/components/HeroSection.jsx
- client/src/components/HandymanBookingForm.jsx
- client/src/routes/RequestPage.jsx
- server/routes/subscribe.js

Existing Stripe subscriptions, the regular /request flow, authentication, admin pages, and other backend routes are preserved.