### PR TITLE
Force refresh services styling and prevent stale HTML

### DIFF
--- a/client/src/services-page.css
+++ b/client/src/services-page.css
@@ -1,95 +1,81 @@
-/* Scoped presentation for the public services directory. */
+/* Fixlo services UI v2 — cache-busting scoped presentation. */
 .fixlo-services-page {
+  isolation: isolate;
   min-height: 100vh;
   padding-bottom: 6.5rem;
-  background:
-    radial-gradient(circle at top right, rgba(251, 191, 36, 0.12), transparent 28rem),
-    #f7f5ef;
+  background: radial-gradient(circle at top right, rgba(251, 191, 36, 0.12), transparent 28rem), #f7f5ef !important;
   color: #171717;
 }
 
 .fixlo-services-page .services-hero {
   overflow: hidden;
-  border: 1px solid rgba(251, 191, 36, 0.28);
+  border: 1px solid rgba(251, 191, 36, 0.28) !important;
   border-radius: 1.5rem;
-  background: #0a0a0a;
-  color: #fff;
+  background: #0a0a0a !important;
+  color: #fff !important;
   box-shadow: 0 18px 48px rgba(0, 0, 0, 0.16);
 }
 
 .fixlo-services-page .services-hero h1,
-.fixlo-services-page .services-hero p {
-  color: #fff !important;
-}
-
-.fixlo-services-page .services-gold {
-  color: #fbbf24 !important;
-}
+.fixlo-services-page .services-hero p { color: #fff !important; }
+.fixlo-services-page .services-gold { color: #fbbf24 !important; }
 
 .fixlo-services-page .services-trust {
-  border: 1px solid #eadfbd;
-  background: #fff;
+  border: 1px solid #eadfbd !important;
+  background: #fff !important;
   box-shadow: 0 12px 34px rgba(25, 21, 12, 0.07);
 }
 
 .fixlo-services-page .services-card {
-  border: 1px solid #e6dfcf;
+  border: 1px solid #e6dfcf !important;
   border-radius: 1.15rem;
-  background: #fff;
+  background: #fff !important;
   box-shadow: 0 10px 28px rgba(25, 21, 12, 0.06);
   transition: transform 180ms ease, box-shadow 180ms ease, border-color 180ms ease;
 }
 
 .fixlo-services-page .services-card:hover {
   transform: translateY(-3px);
-  border-color: rgba(245, 158, 11, 0.58);
+  border-color: rgba(245, 158, 11, 0.58) !important;
   box-shadow: 0 18px 40px rgba(25, 21, 12, 0.11);
 }
 
-.fixlo-services-page .services-button {
-  display: inline-flex;
+.fixlo-services-page .services-button,
+.fixlo-services-page a.services-button {
+  display: inline-flex !important;
   align-items: center;
   justify-content: center;
   min-height: 2.9rem;
-  border: 1px solid #fbbf24;
+  border: 1px solid #fbbf24 !important;
   border-radius: 0.85rem;
   padding: 0.75rem 1.2rem;
-  background: #fbbf24;
+  background: #fbbf24 !important;
   color: #111 !important;
   font-weight: 800;
   box-shadow: 0 8px 20px rgba(245, 158, 11, 0.2);
   transition: background-color 180ms ease, transform 180ms ease, box-shadow 180ms ease;
 }
 
-.fixlo-services-page .services-button:hover {
+.fixlo-services-page .services-button:hover,
+.fixlo-services-page a.services-button:hover {
   transform: translateY(-1px);
-  background: #f59e0b;
+  background: #f59e0b !important;
+  color: #000 !important;
   box-shadow: 0 10px 24px rgba(245, 158, 11, 0.3);
 }
 
-.fixlo-services-page .services-city-link {
-  color: #a16207 !important;
-  font-weight: 700;
-}
+.fixlo-services-page .services-city-link { color: #a16207 !important; font-weight: 700; }
+.fixlo-services-page .services-city-link:hover { color: #111 !important; }
 
-.fixlo-services-page .services-city-link:hover {
+.fixlo-sticky-pro-cta button {
+  background: #fbbf24 !important;
+  border-color: #fbbf24 !important;
   color: #111 !important;
 }
 
 @media (max-width: 767px) {
-  .fixlo-services-page {
-    padding-bottom: 7.5rem;
-  }
-
-  .fixlo-services-page .services-hero {
-    border-radius: 1.1rem;
-  }
-
-  .fixlo-services-page .services-card {
-    padding: 1.35rem !important;
-  }
-
-  .fixlo-services-page .services-button {
-    width: 100%;
-  }
+  .fixlo-services-page { padding-bottom: 7.5rem; }
+  .fixlo-services-page .services-hero { border-radius: 1.1rem; }
+  .fixlo-services-page .services-card { padding: 1.35rem !important; }
+  .fixlo-services-page .services-button { width: 100%; }
 }

--- a/client/vercel.json
+++ b/client/vercel.json
@@ -3,6 +3,26 @@
   "rewrites": [
     { "source": "/(.*)", "destination": "/" }
   ],
+  "headers": [
+    {
+      "source": "/",
+      "headers": [
+        { "key": "Cache-Control", "value": "no-cache, no-store, must-revalidate" }
+      ]
+    },
+    {
+      "source": "/services",
+      "headers": [
+        { "key": "Cache-Control", "value": "no-cache, no-store, must-revalidate" }
+      ]
+    },
+    {
+      "source": "/dashboard(.*)",
+      "headers": [
+        { "key": "Cache-Control", "value": "no-cache, no-store, must-revalidate" }
+      ]
+    }
+  ],
   "installCommand": "npm ci",
   "buildCommand": "npm run build",
   "outputDirectory": "dist"


### PR DESCRIPTION
Fixes the issue where Safari/Vercel continued serving the old services UI even after the black-and-gold redesign was merged.

Changes:
- Adds no-store/no-cache headers for `/`, `/services`, and dashboard routes so stale SPA HTML is not reused
- Forces a new services CSS asset hash
- Strengthens scoped black-and-gold button/card overrides so legacy red brand styles cannot win
- Keeps all service routes and click behavior unchanged

Files changed:
- client/vercel.json
- client/src/services-page.css