### PR TITLE
Enroll manually imported Pro leads in automatic follow-ups

### DIFF
--- a/server/services/proFollowUpAutoRepair.js
+++ b/server/services/proFollowUpAutoRepair.js
@@ -1,13 +1,8 @@
 'use strict';
 
 /**
- * Automatically repairs missing Meta Pro lead follow-up dates.
- *
- * The normal scheduler only selects leads whose next follow-up date is due.
- * Older/manual imports can have null scheduling fields, so MongoDB never
- * returns them. This lightweight worker repairs only active, unregistered,
- * reachable leads. The existing scheduler then sends the messages using the
- * production delivery and idempotency logic.
+ * Automatically enrolls and repairs manually imported Meta Pro leads so the
+ * existing production follow-up scheduler can send SMS and email reminders.
  */
 
 const cron = require('node-cron');
@@ -28,7 +23,10 @@ function nextDate(base, step, timings) {
 }
 
 async function repairMissingProFollowUpSchedules() {
-  if (repairRunning || mongoose.connection.readyState !== 1) return { repaired: 0, skipped: true };
+  if (repairRunning || mongoose.connection.readyState !== 1) {
+    return { repaired: 0, enrolled: 0, skipped: true };
+  }
+
   repairRunning = true;
 
   try {
@@ -37,15 +35,18 @@ async function repairMissingProFollowUpSchedules() {
     const settings = await getSettings();
 
     if (!settings.enabled || !settings.automaticReminders) {
-      return { repaired: 0, skipped: true, reason: 'automation_disabled' };
+      return { repaired: 0, enrolled: 0, skipped: true, reason: 'automation_disabled' };
     }
 
     const timings = settings.followUpTimingsHours || [24, 72, 168, 336];
+
+    // Include manually imported leads even when followUp/status fields were
+    // never initialized. Hard-stop only genuinely completed or closed leads.
     const leads = await MetaLead.find({
-      'followUp.status': 'active',
-      registrationStatus: 'not_registered',
+      registrationStatus: { $in: ['not_registered', null, ''] },
       leadStatus: { $nin: ['closed', 'registered', 'subscribed'] },
       $or: [
+        { manualImport: true },
         { 'followUp.nextSmsFollowUpAt': null },
         { 'followUp.nextSmsFollowUpAt': { $exists: false } },
         { 'followUp.nextEmailFollowUpAt': null },
@@ -53,14 +54,35 @@ async function repairMissingProFollowUpSchedules() {
         { 'followUp.nextFollowUpAt': null },
         { 'followUp.nextFollowUpAt': { $exists: false } }
       ]
-    }).limit(250);
+    }).limit(500);
 
     let repaired = 0;
+    let enrolled = 0;
 
     for (const lead of leads) {
+      const followUpStatus = String(lead.followUp?.status || '').toLowerCase();
+      if (['stopped', 'paused', 'completed'].includes(followUpStatus)) continue;
+
       let changed = false;
-      const smsStep = Math.max(0, Number(lead.followUp?.smsStep || 0));
-      const emailStep = Math.max(0, Number(lead.followUp?.emailStep || 0));
+
+      if (!lead.followUp || Array.isArray(lead.followUp) || typeof lead.followUp !== 'object') {
+        lead.followUp = {};
+        changed = true;
+      }
+
+      if (!followUpStatus) {
+        lead.followUp.status = 'active';
+        enrolled += 1;
+        changed = true;
+      }
+
+      if (!lead.registrationStatus) {
+        lead.registrationStatus = 'not_registered';
+        changed = true;
+      }
+
+      const smsStep = Math.max(0, Number(lead.followUp.smsStep || 0));
+      const emailStep = Math.max(0, Number(lead.followUp.emailStep || 0));
       const smsAvailable = Boolean(normalizePhone(lead.phone)) && !lead.smsOptOut && smsStep < STAGE_COUNT;
       const emailAvailable = validEmail(lead.email)
         && String(lead.emailStatus || '').toLowerCase() !== 'unsubscribed'
@@ -70,13 +92,14 @@ async function repairMissingProFollowUpSchedules() {
         lead.followUp.smsEnabled = smsAvailable;
         changed = true;
       }
+
       if (lead.followUp.emailEnabled !== emailAvailable) {
         lead.followUp.emailEnabled = emailAvailable;
         changed = true;
       }
 
       if (smsAvailable && !lead.followUp.nextSmsFollowUpAt) {
-        const base = lead.followUp.initialSmsSentAt || lead.createdAt;
+        const base = lead.followUp.initialSmsSentAt || lead.createdAt || new Date();
         const scheduled = nextDate(base, smsStep, timings);
         if (scheduled) {
           lead.followUp.smsStep = smsStep;
@@ -86,7 +109,7 @@ async function repairMissingProFollowUpSchedules() {
       }
 
       if (emailAvailable && !lead.followUp.nextEmailFollowUpAt) {
-        const base = lead.followUp.initialEmailSentAt || lead.createdAt;
+        const base = lead.followUp.initialEmailSentAt || lead.createdAt || new Date();
         const scheduled = nextDate(base, emailStep, timings);
         if (scheduled) {
           lead.followUp.emailStep = emailStep;
@@ -100,8 +123,11 @@ async function repairMissingProFollowUpSchedules() {
         .map((date) => new Date(date))
         .filter((date) => !Number.isNaN(date.getTime()))
         .sort((a, b) => a - b);
+
       const unified = dates[0] || null;
-      const currentTime = lead.followUp.nextFollowUpAt ? new Date(lead.followUp.nextFollowUpAt).getTime() : null;
+      const currentTime = lead.followUp.nextFollowUpAt
+        ? new Date(lead.followUp.nextFollowUpAt).getTime()
+        : null;
       const unifiedTime = unified ? unified.getTime() : null;
 
       if (currentTime !== unifiedTime) {
@@ -110,31 +136,28 @@ async function repairMissingProFollowUpSchedules() {
       }
 
       if (!smsAvailable && !emailAvailable) continue;
+
       if (changed) {
         await lead.save();
         repaired += 1;
       }
     }
 
-    if (repaired > 0) {
-      console.log(`[PRO_FOLLOWUP_REPAIR] Repaired ${repaired} lead schedule(s); normal follow-up scheduler will process them.`);
-    }
-    return { repaired, scanned: leads.length };
+    console.log(`[PRO_FOLLOWUP_REPAIR] Scanned ${leads.length}; enrolled ${enrolled}; repaired ${repaired}.`);
+    return { repaired, enrolled, scanned: leads.length };
   } catch (error) {
     console.error(`[PRO_FOLLOWUP_REPAIR] Failed: ${error.message}`);
-    return { repaired: 0, error: error.message };
+    return { repaired: 0, enrolled: 0, error: error.message };
   } finally {
     repairRunning = false;
   }
 }
 
-// Run shortly after startup, once MongoDB has had time to connect.
 const startupTimer = setTimeout(() => {
   repairMissingProFollowUpSchedules().catch(() => {});
 }, 30000);
 startupTimer.unref?.();
 
-// Run two minutes before the existing five-minute follow-up cycle.
 cron.schedule('2-59/5 * * * *', () => {
   repairMissingProFollowUpSchedules().catch(() => {});
 }, { scheduled: true, timezone: 'America/New_York' });


### PR DESCRIPTION
## Summary
- Expands the automatic Pro follow-up repair worker so manually imported leads are enrolled even when `followUp.status` and scheduling fields were never initialized.
- Preserves hard stops for closed, registered, subscribed, paused, stopped, completed, opted-out, or unreachable leads.
- Initializes `registrationStatus`, `followUp.status`, channel enable flags, per-channel next dates, and unified next follow-up date.
- Adds explicit logs showing scanned, enrolled, and repaired counts every repair cycle.

## Why
Production logs repeatedly showed `META_FOLLOWUP Candidates: 0` because manually imported leads could have null or missing follow-up fields and therefore never matched the scheduler query.

## Safety
- Does not send messages directly.
- Reuses the existing production follow-up scheduler, Twilio/SendGrid delivery, opt-out rules, and duplicate protection.
- No frontend, Stripe, homeowner request, authentication, or lead-routing behavior changed.

## Expected Render proof
After deploy, logs should include:
`[PRO_FOLLOWUP_REPAIR] Scanned X; enrolled Y; repaired Z.`
Then the following `META_FOLLOWUP` cycle should show non-zero candidates for due eligible leads.