### PR TITLE
Load Pro follow-up worker without modifying server index

### DIFF
--- a/server/config/.followup-worker-load-note
+++ b/server/config/.followup-worker-load-note
@@ -1,0 +1,1 @@
+This marker documents that proFollowUpAutoRepair is loaded from database.js so Render's `node index.js` start command initializes the worker without replacing server/index.js.

--- a/server/config/database.js
+++ b/server/config/database.js
@@ -1,5 +1,11 @@
 const mongoose = require('mongoose');
 
+// Load the Pro follow-up repair worker through a small, stable startup module.
+// Render starts production with `node index.js`, and index.js always imports
+// this database config before connecting. Node's module cache prevents a
+// duplicate worker if package.json also preloads it through `-r`.
+require('../services/proFollowUpAutoRepair');
+
 const MONGO_ENV_KEYS = ['MONGODB_URI', 'MONGO_URI', 'DATABASE_URL'];
 const LOCAL_SANDBOX_WARNING = 'MongoDB URI missing or invalid in local/sandbox environment. Skipping database connection.';
 const SUPPORTED_MONGO_PROTOCOLS = new Set(['mongodb:', 'mongodb+srv:']);


### PR DESCRIPTION
## Summary
- Loads `proFollowUpAutoRepair` from the existing database startup module that `server/index.js` already imports.
- Keeps the complete production `server/index.js` untouched.
- Preserves the restored routes, Stripe webhooks, schedulers, authentication, dashboards, and API startup behavior.
- Allows Render's existing `node index.js` command to initialize the manual Pro lead follow-up repair worker.

## Why
The previous approach accidentally replaced most of `server/index.js` and caused `Cannot find module './routes/homeowner'`. This is a minimal startup hook in `server/config/database.js` only.

## Expected Render logs
- `[PRO_FOLLOWUP_REPAIR] Worker initialized`
- `MongoDB connected`
- `🚀 Fixlo API listening on port 10000`
- about 30 seconds later: `[PRO_FOLLOWUP_REPAIR] Scanned X; enrolled Y; repaired Z.`
- the next follow-up cycle should process due manually imported Pro leads.

## Safety
- No missing or renamed routes.
- No frontend changes.
- No Stripe, auth, lead-routing, or scheduler replacement.
- Node module caching prevents duplicate initialization if the worker is also preloaded through `-r`.