### PR TITLE
Make manual Pro follow-ups due immediately

### DIFF
--- a/server/services/proFollowUpAutoRepair.js
+++ b/server/services/proFollowUpAutoRepair.js
@@ -9,6 +9,7 @@ const cron = require('node-cron');
 const mongoose = require('mongoose');
 
 const STAGE_COUNT = 4;
+const IMMEDIATE_DUE_OFFSET_MS = 60 * 1000;
 let repairRunning = false;
 
 function validEmail(value) {
@@ -22,9 +23,15 @@ function nextDate(base, step, timings) {
   return new Date(new Date(base).getTime() + hours * 60 * 60 * 1000);
 }
 
+function isFutureDate(value, now) {
+  if (!value) return false;
+  const date = new Date(value);
+  return !Number.isNaN(date.getTime()) && date.getTime() > now.getTime();
+}
+
 async function repairMissingProFollowUpSchedules() {
   if (repairRunning || mongoose.connection.readyState !== 1) {
-    return { repaired: 0, enrolled: 0, skipped: true };
+    return { repaired: 0, enrolled: 0, forcedDue: 0, skipped: true };
   }
 
   repairRunning = true;
@@ -35,13 +42,16 @@ async function repairMissingProFollowUpSchedules() {
     const settings = await getSettings();
 
     if (!settings.enabled || !settings.automaticReminders) {
-      return { repaired: 0, enrolled: 0, skipped: true, reason: 'automation_disabled' };
+      return {
+        repaired: 0,
+        enrolled: 0,
+        forcedDue: 0,
+        skipped: true,
+        reason: 'automation_disabled'
+      };
     }
 
     const timings = settings.followUpTimingsHours || [24, 72, 168, 336];
-
-    // Include manually imported leads even when followUp/status fields were
-    // never initialized. Hard-stop only genuinely completed or closed leads.
     const leads = await MetaLead.find({
       registrationStatus: { $in: ['not_registered', null, ''] },
       leadStatus: { $nin: ['closed', 'registered', 'subscribed'] },
@@ -58,6 +68,7 @@ async function repairMissingProFollowUpSchedules() {
 
     let repaired = 0;
     let enrolled = 0;
+    let forcedDue = 0;
 
     for (const lead of leads) {
       const followUpStatus = String(lead.followUp?.status || '').toLowerCase();
@@ -83,7 +94,9 @@ async function repairMissingProFollowUpSchedules() {
 
       const smsStep = Math.max(0, Number(lead.followUp.smsStep || 0));
       const emailStep = Math.max(0, Number(lead.followUp.emailStep || 0));
-      const smsAvailable = Boolean(normalizePhone(lead.phone)) && !lead.smsOptOut && smsStep < STAGE_COUNT;
+      const smsAvailable = Boolean(normalizePhone(lead.phone))
+        && !lead.smsOptOut
+        && smsStep < STAGE_COUNT;
       const emailAvailable = validEmail(lead.email)
         && String(lead.emailStatus || '').toLowerCase() !== 'unsubscribed'
         && emailStep < STAGE_COUNT;
@@ -118,6 +131,31 @@ async function repairMissingProFollowUpSchedules() {
         }
       }
 
+      // Existing manually imported leads were already initialized with future
+      // dates, so the normal scheduler kept returning Candidates: 0. Make each
+      // eligible manual lead due once, then persist a marker so later repair
+      // cycles never keep forcing the schedule backward.
+      if (lead.manualImport === true && !lead.followUp.manualImportImmediateEnrollmentAt) {
+        const now = new Date();
+        const dueAt = new Date(now.getTime() - IMMEDIATE_DUE_OFFSET_MS);
+        let madeDue = false;
+
+        if (smsAvailable && (!lead.followUp.nextSmsFollowUpAt || isFutureDate(lead.followUp.nextSmsFollowUpAt, now))) {
+          lead.followUp.nextSmsFollowUpAt = dueAt;
+          madeDue = true;
+        }
+
+        if (emailAvailable && (!lead.followUp.nextEmailFollowUpAt || isFutureDate(lead.followUp.nextEmailFollowUpAt, now))) {
+          lead.followUp.nextEmailFollowUpAt = dueAt;
+          madeDue = true;
+        }
+
+        lead.followUp.manualImportImmediateEnrollmentAt = now;
+        changed = true;
+
+        if (madeDue) forcedDue += 1;
+      }
+
       const dates = [lead.followUp.nextSmsFollowUpAt, lead.followUp.nextEmailFollowUpAt]
         .filter(Boolean)
         .map((date) => new Date(date))
@@ -143,11 +181,15 @@ async function repairMissingProFollowUpSchedules() {
       }
     }
 
-    console.log(`[PRO_FOLLOWUP_REPAIR] Scanned ${leads.length}; enrolled ${enrolled}; repaired ${repaired}.`);
-    return { repaired, enrolled, scanned: leads.length };
+    console.log(
+      `[PRO_FOLLOWUP_REPAIR] Scanned ${leads.length}; enrolled ${enrolled}; `
+      + `forced due ${forcedDue}; repaired ${repaired}.`
+    );
+
+    return { repaired, enrolled, forcedDue, scanned: leads.length };
   } catch (error) {
     console.error(`[PRO_FOLLOWUP_REPAIR] Failed: ${error.message}`);
-    return { repaired: 0, enrolled: 0, error: error.message };
+    return { repaired: 0, enrolled: 0, forcedDue: 0, error: error.message };
   } finally {
     repairRunning = false;
   }


### PR DESCRIPTION
## Summary
- Makes eligible manually imported Pro leads due immediately one time when their existing follow-up dates are still in the future.
- Adds a persistent `manualImportImmediateEnrollmentAt` marker so later repair cycles do not keep forcing dates backward.
- Preserves STOP/unsubscribe, closed/registered/subscribed, paused/stopped/completed, channel eligibility, and existing duplicate-send protection.
- Keeps the existing scheduler, Twilio, and SendGrid delivery paths unchanged.

## Why
Production proved the worker was active and scanned 4 leads, but reported `enrolled 0; repaired 0`, while `META_FOLLOWUP` stayed at `Candidates: 0`. Those leads had already-initialized future dates, so the previous repair logic did not modify them.

## Expected logs
`[PRO_FOLLOWUP_REPAIR] Scanned 4; enrolled 0; forced due N; repaired N.`

Then on the next five-minute cycle:
- `Candidates: N`
- non-zero eligible SMS/email counts for reachable leads
- successful sends or explicit provider failures/skips

## Safety
This only accelerates the current pending stage once for `manualImport: true` leads. It does not reset stages or bypass consent and opt-out rules.