### PR TITLE
Add homeowner local service SEO engine

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -3,12 +3,13 @@
   "version": "1.7.0",
   "type": "module",
   "scripts": {
-    "prebuild": "node scripts/fix-admin-jobs-syntax.mjs && node scripts/fetch-images.mjs && node scripts/generate-pro-seo-pages.mjs",
+    "prebuild": "node scripts/fix-admin-jobs-syntax.mjs && node scripts/fetch-images.mjs && node scripts/generate-pro-seo-pages.mjs && node scripts/generate-homeowner-seo-pages.mjs && node scripts/generate-sitemap.mjs",
     "build": "npm run prebuild && vite build",
     "dev": "vite",
     "preview": "vite preview",
     "generate:sitemap": "node scripts/generate-sitemap.mjs",
     "generate:pro-seo": "node scripts/generate-pro-seo-pages.mjs",
+    "generate:homeowner-seo": "node scripts/generate-homeowner-seo-pages.mjs",
     "cap:sync": "npx cap sync",
     "cap:open:ios": "npx cap open ios",
     "cap:open:android": "npx cap open android"

--- a/client/scripts/generate-homeowner-seo-pages.mjs
+++ b/client/scripts/generate-homeowner-seo-pages.mjs
@@ -1,0 +1,137 @@
+import fs from 'fs';
+import path from 'path';
+import { PRO_CITIES } from '../src/seo/proSeoData.js';
+import { HOMEOWNER_SERVICES } from '../src/seo/homeownerSeoData.js';
+
+const PUBLIC_DIR = path.join(process.cwd(), 'public');
+const SITE = 'https://www.fixloapp.com';
+
+function escapeHtml(value = '') {
+  return String(value)
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+    .replaceAll("'", '&#039;');
+}
+
+function renderFaq(service, city) {
+  return service.questions.map((question, index) => {
+    const answers = [
+      `Pricing varies by project scope, property conditions, materials, and the professional selected. Submit your request through Fixlo to share the details and connect with local professionals serving ${city.city}.`,
+      `Include photos, measurements, timing, and a clear description of the work. Better project details help professionals understand the request before following up.`,
+      `Yes. Fixlo supports both small repair requests and larger projects. Availability depends on the service, location, and professionals active in the area.`
+    ];
+    return { q: question, a: answers[index] || answers[0] };
+  });
+}
+
+function renderPage(serviceSlug, service, citySlug, city) {
+  const location = `${city.city}, ${city.state}`;
+  const canonical = `${SITE}/services/${serviceSlug}/${citySlug}`;
+  const title = `${service.label} in ${location} | Request Service with Fixlo`;
+  const description = `Need ${service.label.toLowerCase()} in ${location}? Submit your project through Fixlo and connect with local professionals for estimates, repairs, installations, and home improvements.`;
+  const faq = renderFaq(service, city);
+  const relatedServices = Object.entries(HOMEOWNER_SERVICES)
+    .filter(([slug]) => slug !== serviceSlug)
+    .slice(0, 8)
+    .map(([slug, item]) => `<a href="/services/${slug}/${citySlug}">${escapeHtml(item.label)} in ${escapeHtml(city.city)}</a>`)
+    .join('');
+  const nearbyCities = Object.entries(PRO_CITIES)
+    .filter(([slug, item]) => slug !== citySlug && item.state === city.state)
+    .slice(0, 8)
+    .map(([slug, item]) => `<a href="/services/${serviceSlug}/${slug}">${escapeHtml(service.label)} in ${escapeHtml(item.city)}, ${escapeHtml(item.state)}</a>`)
+    .join('');
+
+  const schema = {
+    '@context': 'https://schema.org',
+    '@graph': [
+      {
+        '@type': 'WebPage',
+        name: title,
+        description,
+        url: canonical,
+        about: {
+          '@type': 'Service',
+          name: service.label,
+          areaServed: { '@type': 'City', name: location },
+          provider: { '@type': 'Organization', name: 'Fixlo', url: SITE }
+        }
+      },
+      {
+        '@type': 'FAQPage',
+        mainEntity: faq.map((item) => ({
+          '@type': 'Question',
+          name: item.q,
+          acceptedAnswer: { '@type': 'Answer', text: item.a }
+        }))
+      },
+      {
+        '@type': 'BreadcrumbList',
+        itemListElement: [
+          { '@type': 'ListItem', position: 1, name: 'Fixlo', item: `${SITE}/` },
+          { '@type': 'ListItem', position: 2, name: 'Services', item: `${SITE}/services` },
+          { '@type': 'ListItem', position: 3, name: service.label, item: `${SITE}/services/${serviceSlug}` },
+          { '@type': 'ListItem', position: 4, name: location, item: canonical }
+        ]
+      }
+    ]
+  };
+
+  return `<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>${escapeHtml(title)}</title>
+  <meta name="description" content="${escapeHtml(description)}" />
+  <meta name="robots" content="index, follow" />
+  <link rel="canonical" href="${canonical}" />
+  <meta property="og:type" content="website" />
+  <meta property="og:site_name" content="Fixlo" />
+  <meta property="og:title" content="${escapeHtml(title)}" />
+  <meta property="og:description" content="${escapeHtml(description)}" />
+  <meta property="og:url" content="${canonical}" />
+  <meta property="og:image" content="${SITE}/cover.png" />
+  <meta name="twitter:card" content="summary_large_image" />
+  <script type="application/ld+json">${JSON.stringify(schema)}</script>
+  <style>
+    :root{color-scheme:dark;--gold:#f4c542;--ink:#080808;--muted:#b9bdc6}*{box-sizing:border-box}body{margin:0;font-family:Inter,ui-sans-serif,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif;background:var(--ink);color:#fff;line-height:1.6}a{color:inherit}.wrap{width:min(1120px,calc(100% - 32px));margin:auto}.nav{display:flex;justify-content:space-between;align-items:center;padding:22px 0}.brand{font-size:28px;font-weight:900;letter-spacing:.04em}.brand span{color:var(--gold)}.nav a,.button{display:inline-flex;text-decoration:none;font-weight:800;border-radius:999px;padding:12px 20px}.nav a{border:1px solid #333}.hero{display:grid;grid-template-columns:1.15fr .85fr;gap:48px;align-items:center;padding:64px 0 88px}.eyebrow{color:var(--gold);font-weight:900;text-transform:uppercase;letter-spacing:.18em;font-size:13px}.hero h1{font-size:clamp(42px,7vw,72px);line-height:1.03;margin:14px 0 22px}.hero p{color:var(--muted);font-size:19px;max-width:680px}.actions{display:flex;gap:12px;flex-wrap:wrap;margin-top:30px}.button.primary{background:var(--gold);color:#111}.button.secondary{border:1px solid #555}.card{border:1px solid rgba(244,197,66,.35);background:#121212;border-radius:28px;padding:28px}.card ul{padding:0;margin:20px 0 0;list-style:none}.card li{padding:13px 0;border-bottom:1px solid #292929}.card li:before{content:"✓";color:var(--gold);margin-right:10px;font-weight:900}.light{background:#fff;color:#111;padding:72px 0}.grid{display:grid;grid-template-columns:repeat(2,1fr);gap:28px}.feature{border:1px solid #e5e7eb;border-radius:22px;padding:24px}.steps{background:#111;color:#fff}.steps strong{color:var(--gold)}.faq{background:#f3f4f6;color:#111;padding:72px 0}.faq-grid{display:grid;grid-template-columns:repeat(3,1fr);gap:20px}.faq article{background:#fff;border-radius:22px;padding:24px}.links{display:flex;flex-wrap:wrap;gap:10px}.links a{border:1px solid #d1d5db;border-radius:999px;padding:9px 14px;text-decoration:none;font-size:14px}.fine{color:#8b909a;font-size:13px;margin-top:18px}footer{padding:34px 0;color:#9297a0;text-align:center}@media(max-width:800px){.hero,.grid,.faq-grid{grid-template-columns:1fr}.hero{padding-top:38px}.hero h1{font-size:44px}}
+  </style>
+</head>
+<body>
+  <header class="wrap nav"><div class="brand">FIX<span>LO</span></div><a href="/services">Browse Services</a></header>
+  <main>
+    <section class="wrap hero">
+      <div>
+        <div class="eyebrow">Local home-service request</div>
+        <h1>${escapeHtml(service.label)} in ${escapeHtml(location)}</h1>
+        <p>${escapeHtml(service.intro)} Tell Fixlo what you need and connect with professionals serving ${escapeHtml(city.region)}.</p>
+        <div class="actions"><a class="button primary" href="/request?service=${encodeURIComponent(serviceSlug)}&city=${encodeURIComponent(citySlug)}">Request Service</a><a class="button secondary" href="/services/${serviceSlug}">Learn about this service</a></div>
+        <div class="fine">Availability, pricing, licensing, and project terms vary by professional and location.</div>
+      </div>
+      <aside class="card"><div class="eyebrow">Common requests</div><ul>${service.tasks.map((task) => `<li>${escapeHtml(task)}</li>`).join('')}</ul></aside>
+    </section>
+
+    <section class="light"><div class="wrap grid"><div><div class="eyebrow">How Fixlo works</div><h2>Describe the project once</h2><p>Add the work needed, location, timing, photos, and project details. Clear requests make it easier for professionals to evaluate the job.</p><div class="grid"><div class="feature">Local service matching</div><div class="feature">Mobile-friendly request form</div><div class="feature">Project details in one place</div><div class="feature">No obligation to accept an estimate</div></div></div><div class="card steps"><h2>Request ${escapeHtml(service.label.toLowerCase())}</h2><p><strong>1.</strong> Describe the project.</p><p><strong>2.</strong> Add your location and contact details.</p><p><strong>3.</strong> Upload photos when helpful.</p><p><strong>4.</strong> Review responses from available professionals.</p><a class="button primary" href="/request?service=${encodeURIComponent(serviceSlug)}&city=${encodeURIComponent(citySlug)}">Start your request</a></div></div></section>
+
+    <section class="faq"><div class="wrap"><h2>Questions about ${escapeHtml(service.label.toLowerCase())}</h2><div class="faq-grid">${faq.map((item) => `<article><h3>${escapeHtml(item.q)}</h3><p>${escapeHtml(item.a)}</p></article>`).join('')}</div></div></section>
+
+    <section class="light"><div class="wrap grid"><div><h2>Other services in ${escapeHtml(city.city)}</h2><div class="links">${relatedServices}</div></div><div><h2>${escapeHtml(service.label)} in nearby markets</h2><div class="links">${nearbyCities || `<a href="/services/${serviceSlug}">View all ${escapeHtml(service.label.toLowerCase())} information</a>`}</div></div></div></section>
+  </main>
+  <footer class="wrap">© ${new Date().getFullYear()} Fixlo · Find. Book. Get It Done.</footer>
+</body>
+</html>`;
+}
+
+let count = 0;
+for (const [serviceSlug, service] of Object.entries(HOMEOWNER_SERVICES)) {
+  for (const [citySlug, city] of Object.entries(PRO_CITIES)) {
+    const targetDir = path.join(PUBLIC_DIR, 'services', serviceSlug, citySlug);
+    fs.mkdirSync(targetDir, { recursive: true });
+    fs.writeFileSync(path.join(targetDir, 'index.html'), renderPage(serviceSlug, service, citySlug, city), 'utf8');
+    count += 1;
+  }
+}
+
+console.info(`[homeowner-seo] Generated ${count} homeowner service pages in ${PUBLIC_DIR}`);

--- a/client/scripts/generate-sitemap.mjs
+++ b/client/scripts/generate-sitemap.mjs
@@ -2,24 +2,14 @@
 import fs from "fs";
 import path from "path";
 import { PRO_CITIES, PRO_TRADES } from "../src/seo/proSeoData.js";
+import { HOMEOWNER_SERVICES } from "../src/seo/homeownerSeoData.js";
 
 const PUBLIC_DIR = path.join(process.cwd(), "public");
 const SITE = "https://www.fixloapp.com";
 const TODAY = new Date().toISOString().slice(0, 10);
 
 const STATIC_PATHS = [
-  "/", "/pricing", "/services", "/terms", "/pros", "/pros/signup"
-];
-
-const SERVICES = [
-  "plumbing", "electrical", "carpentry", "painting", "hvac",
-  "roofing", "landscaping", "house-cleaning", "junk-removal", "handyman"
-];
-
-const CITIES = [
-  "charlotte-nc", "raleigh-nc", "greensboro-nc", "atlanta-ga",
-  "miami-fl", "orlando-fl", "tampa-fl", "los-angeles-ca",
-  "chicago-il", "houston-tx", "dallas-tx", "phoenix-az"
+  "/", "/pricing", "/services", "/terms", "/pros", "/pros/signup", "/request"
 ];
 
 const url = (p) => `${SITE}${p.startsWith("/") ? "" : "/"}${p}`.replace(/\/+$/, "");
@@ -40,12 +30,12 @@ function generateURLs() {
 
   STATIC_PATHS.forEach((p) => urls.add(makeURLEntry(url(p), "0.80", "weekly")));
 
-  SERVICES.forEach((service) => {
-    urls.add(makeURLEntry(url(`/services/${service}`), "0.80", "weekly"));
-    CITIES.forEach((city) => {
-      urls.add(makeURLEntry(url(`/services/${service}/${city}`), "0.60", "weekly"));
-    });
-  });
+  for (const serviceSlug of Object.keys(HOMEOWNER_SERVICES)) {
+    urls.add(makeURLEntry(url(`/services/${serviceSlug}`), "0.84", "weekly"));
+    for (const citySlug of Object.keys(PRO_CITIES)) {
+      urls.add(makeURLEntry(url(`/services/${serviceSlug}/${citySlug}`), "0.76", "weekly"));
+    }
+  }
 
   for (const tradeSlug of Object.keys(PRO_TRADES)) {
     for (const citySlug of Object.keys(PRO_CITIES)) {

--- a/client/src/seo/homeownerSeoData.js
+++ b/client/src/seo/homeownerSeoData.js
@@ -1,0 +1,130 @@
+export const HOMEOWNER_SERVICES = {
+  handyman: {
+    label: 'Handyman Services',
+    singular: 'handyman',
+    intro: 'Get help with repairs, installations, maintenance, and small home improvement projects.',
+    tasks: ['general home repairs', 'door repair and installation', 'drywall patching', 'fixture installation', 'trim and carpentry work'],
+    questions: ['How much does a handyman cost?', 'What types of jobs can a handyman do?', 'How quickly can I request service?']
+  },
+  remodeling: {
+    label: 'Home Remodeling',
+    singular: 'remodeling contractor',
+    intro: 'Connect with professionals for kitchens, bathrooms, basements, and whole-home renovation projects.',
+    tasks: ['kitchen remodeling', 'bathroom remodeling', 'basement finishing', 'room renovations', 'general renovation work'],
+    questions: ['How long does a remodel take?', 'How do I compare remodeling estimates?', 'Can I request help for a partial renovation?']
+  },
+  'bathroom-remodeling': {
+    label: 'Bathroom Remodeling',
+    singular: 'bathroom remodeling contractor',
+    intro: 'Request help for bathroom updates, repairs, fixture replacements, tile, and full renovations.',
+    tasks: ['shower and tub upgrades', 'tile installation', 'vanity replacement', 'fixture updates', 'full bathroom renovation'],
+    questions: ['How much does a bathroom remodel cost?', 'What should I plan before remodeling?', 'Can I request a smaller bathroom update?']
+  },
+  'kitchen-remodeling': {
+    label: 'Kitchen Remodeling',
+    singular: 'kitchen remodeling contractor',
+    intro: 'Find help for cabinet, countertop, flooring, backsplash, lighting, and full kitchen renovation projects.',
+    tasks: ['cabinet installation', 'countertop replacement', 'backsplash installation', 'kitchen flooring', 'full kitchen renovation'],
+    questions: ['How much does a kitchen remodel cost?', 'How long does a kitchen renovation take?', 'Can I remodel in phases?']
+  },
+  carpentry: {
+    label: 'Carpentry Services',
+    singular: 'carpenter',
+    intro: 'Request help with trim, doors, decks, framing, built-ins, and other woodwork projects.',
+    tasks: ['trim carpentry', 'door installation', 'deck repairs', 'custom shelving', 'framing and wood repairs'],
+    questions: ['What does a carpenter typically handle?', 'How much does custom carpentry cost?', 'Can I request repair work instead of new construction?']
+  },
+  painting: {
+    label: 'Painting Services',
+    singular: 'painter',
+    intro: 'Connect with professionals for interior painting, exterior painting, cabinets, and touch-ups.',
+    tasks: ['interior painting', 'exterior painting', 'cabinet painting', 'wall preparation', 'touch-up painting'],
+    questions: ['How much does house painting cost?', 'How long does interior painting take?', 'Do I need to move furniture first?']
+  },
+  flooring: {
+    label: 'Flooring Installation and Repair',
+    singular: 'flooring professional',
+    intro: 'Request help with installation, replacement, repairs, tile, laminate, vinyl, and hardwood flooring.',
+    tasks: ['floor installation', 'floor replacement', 'tile installation', 'laminate and vinyl flooring', 'floor repairs'],
+    questions: ['How much does flooring installation cost?', 'Which flooring is best for my room?', 'Can damaged flooring be repaired?']
+  },
+  drywall: {
+    label: 'Drywall Repair and Installation',
+    singular: 'drywall professional',
+    intro: 'Get help with holes, cracks, water damage, finishing, texture, and new drywall installation.',
+    tasks: ['drywall patching', 'crack repair', 'water-damage repair', 'drywall installation', 'texture matching'],
+    questions: ['How much does drywall repair cost?', 'Can drywall texture be matched?', 'When should drywall be replaced?']
+  },
+  'door-repair': {
+    label: 'Door Repair and Installation',
+    singular: 'door professional',
+    intro: 'Request help with sticking doors, damaged frames, hardware, replacements, and new installations.',
+    tasks: ['interior door replacement', 'exterior door installation', 'door frame repair', 'hardware replacement', 'alignment and adjustment'],
+    questions: ['Why will my door not close properly?', 'How much does door replacement cost?', 'Can an existing frame be reused?']
+  },
+  'deck-repair': {
+    label: 'Deck Repair and Restoration',
+    singular: 'deck professional',
+    intro: 'Find help with damaged boards, railings, stairs, structural repairs, refinishing, and restoration.',
+    tasks: ['deck board replacement', 'railing repair', 'stair repair', 'structural deck repair', 'deck refinishing'],
+    questions: ['How much does deck repair cost?', 'Can a deck be repaired instead of replaced?', 'What are signs of structural damage?']
+  },
+  'fence-repair': {
+    label: 'Fence Repair and Installation',
+    singular: 'fence professional',
+    intro: 'Request help with damaged panels, posts, gates, chain link, wood, vinyl, and new fence installation.',
+    tasks: ['fence panel repair', 'post replacement', 'gate repair', 'chain-link installation', 'wood and vinyl fencing'],
+    questions: ['How much does fence repair cost?', 'Should a damaged post be replaced?', 'Can one fence section be repaired?']
+  },
+  plumbing: {
+    label: 'Plumbing Services',
+    singular: 'plumber',
+    intro: 'Connect with professionals for leaks, fixtures, drains, water heaters, and other plumbing needs.',
+    tasks: ['leak repair', 'fixture replacement', 'drain service', 'water heater work', 'toilet and faucet repair'],
+    questions: ['When should I call a plumber?', 'How much does plumbing repair cost?', 'Can I request a fixture installation?']
+  },
+  electrical: {
+    label: 'Electrical Services',
+    singular: 'electrician',
+    intro: 'Request help with lighting, outlets, switches, panels, troubleshooting, and electrical upgrades.',
+    tasks: ['light fixture installation', 'outlet and switch work', 'electrical troubleshooting', 'panel upgrades', 'ceiling fan installation'],
+    questions: ['When is a licensed electrician required?', 'How much does electrical work cost?', 'Can I request a small electrical job?']
+  },
+  roofing: {
+    label: 'Roof Repair and Replacement',
+    singular: 'roofing professional',
+    intro: 'Find help with leaks, storm damage, inspections, repairs, and roof replacement projects.',
+    tasks: ['roof leak repair', 'storm-damage repair', 'roof inspection', 'shingle replacement', 'full roof replacement'],
+    questions: ['How do I know if my roof needs repair?', 'How much does roof repair cost?', 'When is roof replacement necessary?']
+  },
+  hvac: {
+    label: 'HVAC Repair and Installation',
+    singular: 'HVAC professional',
+    intro: 'Request help with heating, cooling, maintenance, thermostat installation, and system replacement.',
+    tasks: ['AC repair', 'heating repair', 'HVAC maintenance', 'thermostat installation', 'system replacement estimates'],
+    questions: ['Why is my AC not cooling?', 'How often should HVAC be serviced?', 'When should a system be replaced?']
+  },
+  landscaping: {
+    label: 'Landscaping Services',
+    singular: 'landscaping professional',
+    intro: 'Connect with professionals for lawn care, cleanup, planting, drainage, and outdoor improvements.',
+    tasks: ['yard cleanup', 'lawn care', 'planting', 'mulch and edging', 'hardscape projects'],
+    questions: ['How much does landscaping cost?', 'Can I request one-time yard cleanup?', 'What should I include in my request?']
+  },
+  'junk-removal': {
+    label: 'Junk Removal',
+    singular: 'junk removal professional',
+    intro: 'Request removal of furniture, debris, appliances, garage contents, and other unwanted items.',
+    tasks: ['furniture removal', 'garage cleanouts', 'construction debris', 'appliance removal', 'property cleanup'],
+    questions: ['How much does junk removal cost?', 'What items can be removed?', 'Can I request same-week service?']
+  },
+  'house-cleaning': {
+    label: 'House Cleaning Services',
+    singular: 'house-cleaning professional',
+    intro: 'Find help with recurring cleaning, deep cleaning, move-out cleaning, and post-project cleanup.',
+    tasks: ['recurring cleaning', 'deep cleaning', 'move-out cleaning', 'post-construction cleanup', 'one-time home cleaning'],
+    questions: ['How much does house cleaning cost?', 'What is included in a deep clean?', 'Can I request a one-time cleaning?']
+  }
+};
+
+export const HOMEOWNER_SERVICE_SLUGS = Object.keys(HOMEOWNER_SERVICES);


### PR DESCRIPTION
## Summary
- Adds a scalable homeowner SEO data model covering high-intent home-service searches such as handyman, remodeling, bathroom remodeling, kitchen remodeling, drywall, door repair, deck repair, fence repair, plumbing, electrical, roofing, HVAC, landscaping, junk removal, and house cleaning.
- Generates static, indexable service-by-city landing pages for every configured Fixlo city.
- Adds local titles, descriptions, canonical tags, Open Graph metadata, Service schema, FAQ schema, Breadcrumb schema, internal links, and request-service CTAs.
- Updates the build so homeowner SEO pages and the sitemap are regenerated automatically on every Vercel build.
- Expands the sitemap to include every homeowner service and city combination, while preserving the existing Pro acquisition pages.

## Example URLs
- `/services/handyman/charlotte-nc`
- `/services/remodeling/atlanta-ga`
- `/services/bathroom-remodeling/miami-fl`
- `/services/deck-repair/houston-tx`
- `/services/door-repair/raleigh-nc`

## Scope
This first production-safe phase creates thousands of useful service-location pages from the existing nationwide city dataset. It does not promise rankings and does not create fake reviews, locations, or business claims.

## Safety
- No backend, Stripe, auth, lead routing, SMS, email, or dashboard behavior changed.
- Existing `server/index.js` is untouched.
- Uses the current static build approach already used for Pro SEO pages.
