### PR TITLE
Send Pro signups directly to Stripe Checkout

### DIFF
--- a/client/src/pages/auth/ProSignup.jsx
+++ b/client/src/pages/auth/ProSignup.jsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { Link, useNavigate } from 'react-router-dom';
+import { Link } from 'react-router-dom';
 import { useAuth } from '../../context/AuthContext';
 import { API_BASE } from '../../utils/config';
 import logoUrl from '../../assets/fixlo-logo.png';
@@ -20,7 +20,6 @@ const TRADES = [
 ];
 
 export default function ProSignup() {
-  const navigate = useNavigate();
   const { login } = useAuth();
   const [form, setForm] = useState({
     name: '',
@@ -35,15 +34,12 @@ export default function ProSignup() {
   const [smsOptIn, setSmsOptIn] = useState(false);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState('');
-  const [inviteStatus, setInviteStatus] = useState(null); // null | 'valid' | 'invalid'
+  const [inviteStatus, setInviteStatus] = useState(null);
   const [inviteValidating, setInviteValidating] = useState(false);
 
   const handleChange = (e) => {
-    setForm(f => ({ ...f, [e.target.name]: e.target.value }));
-    // Reset invite status when code changes
-    if (e.target.name === 'inviteCode') {
-      setInviteStatus(null);
-    }
+    setForm((current) => ({ ...current, [e.target.name]: e.target.value }));
+    if (e.target.name === 'inviteCode') setInviteStatus(null);
   };
 
   const handleValidateInviteCode = async () => {
@@ -69,18 +65,21 @@ export default function ProSignup() {
   const handleSubmit = async (e) => {
     e.preventDefault();
     setError('');
+
     if (form.password !== form.confirmPassword) {
       setError('Passwords do not match');
       return;
     }
-    // If an invite code is entered but not yet validated (or was invalid), block submit
+
     if (form.inviteCode.trim() && inviteStatus !== 'valid') {
       setError('Please validate your invitation code before continuing.');
       return;
     }
+
     setLoading(true);
+
     try {
-      const res = await fetch(`${API_BASE}/api/auth/signup/pro`, {
+      const signupResponse = await fetch(`${API_BASE}/api/auth/signup/pro`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
@@ -95,18 +94,50 @@ export default function ProSignup() {
           inviteCode: form.inviteCode.trim() || undefined
         })
       });
-      const data = await res.json();
-      if (!res.ok) { setError(data.error || 'Signup failed'); return; }
-      login(data.token, {
+
+      const signupData = await signupResponse.json();
+      if (!signupResponse.ok) {
+        setError(signupData.error || signupData.message || 'Signup failed');
+        return;
+      }
+
+      login(signupData.token, {
         role: 'pro',
-        id: data.pro.id,
-        name: data.pro.name,
-        email: data.pro.email,
-        trade: data.pro.trade,
-        phone: data.pro.phone
+        id: signupData.pro.id,
+        name: signupData.pro.name,
+        email: signupData.pro.email,
+        trade: signupData.pro.trade,
+        phone: signupData.pro.phone
       });
-      // Redirect to pricing if subscription is required
-      navigate(data.pro.requiresSubscription ? '/pricing' : '/dashboard/pro');
+
+      if (!signupData.pro.requiresSubscription) {
+        window.location.assign('/dashboard/pro');
+        return;
+      }
+
+      const checkoutResponse = await fetch(`${API_BASE}/api/stripe/create-checkout-session`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${signupData.token}`
+        },
+        body: JSON.stringify({
+          email: signupData.pro.email,
+          userId: signupData.pro.id,
+          phone: signupData.pro.phone,
+          tier: 'PRO',
+          plan: 'pro',
+          referralCode: form.inviteCode.trim() || undefined
+        })
+      });
+
+      const checkoutData = await checkoutResponse.json();
+      if (!checkoutResponse.ok || !checkoutData.sessionUrl) {
+        setError(checkoutData.message || checkoutData.error || 'Unable to open secure checkout. Please try again.');
+        return;
+      }
+
+      window.location.assign(checkoutData.sessionUrl);
     } catch {
       setError('Network error. Please try again.');
     } finally {
@@ -124,194 +155,70 @@ export default function ProSignup() {
         </div>
 
         <div className="bg-white/10 backdrop-blur-md rounded-2xl p-8 border border-white/20 shadow-2xl">
-          {error && (
-            <div className="mb-4 bg-red-500/20 border border-red-400/40 rounded-lg p-3 text-red-200 text-sm">{error}</div>
-          )}
+          {error && <div className="mb-4 bg-red-500/20 border border-red-400/40 rounded-lg p-3 text-red-200 text-sm">{error}</div>}
 
           <form onSubmit={handleSubmit} className="space-y-4">
             <div>
               <label className="block text-blue-100 text-sm font-medium mb-1">Full Name</label>
-              <input
-                name="name"
-                type="text"
-                value={form.name}
-                onChange={handleChange}
-                required
-                disabled={loading}
-                className="w-full bg-white/10 border border-white/20 rounded-lg px-4 py-2.5 text-white placeholder-blue-300 focus:outline-none focus:ring-2 focus:ring-blue-400"
-                placeholder="Your full name"
-              />
+              <input name="name" type="text" value={form.name} onChange={handleChange} required disabled={loading} className="w-full bg-white/10 border border-white/20 rounded-lg px-4 py-2.5 text-white placeholder-blue-300 focus:outline-none focus:ring-2 focus:ring-blue-400" placeholder="Your full name" />
             </div>
             <div>
               <label className="block text-blue-100 text-sm font-medium mb-1">Trade / Service</label>
-              <select
-                name="trade"
-                value={form.trade}
-                onChange={handleChange}
-                required
-                disabled={loading}
-                className="w-full bg-white/10 border border-white/20 rounded-lg px-4 py-2.5 text-white focus:outline-none focus:ring-2 focus:ring-blue-400"
-              >
+              <select name="trade" value={form.trade} onChange={handleChange} required disabled={loading} className="w-full bg-white/10 border border-white/20 rounded-lg px-4 py-2.5 text-white focus:outline-none focus:ring-2 focus:ring-blue-400">
                 <option value="" className="bg-slate-900">Select your trade…</option>
-                {TRADES.map(t => (
-                  <option key={t.value} value={t.value} className="bg-slate-900">{t.label}</option>
-                ))}
+                {TRADES.map((trade) => <option key={trade.value} value={trade.value} className="bg-slate-900">{trade.label}</option>)}
               </select>
             </div>
             <div>
               <label className="block text-blue-100 text-sm font-medium mb-1">Location</label>
-              <input
-                name="location"
-                type="text"
-                value={form.location}
-                onChange={handleChange}
-                required
-                disabled={loading}
-                className="w-full bg-white/10 border border-white/20 rounded-lg px-4 py-2.5 text-white placeholder-blue-300 focus:outline-none focus:ring-2 focus:ring-blue-400"
-                placeholder="City, State"
-              />
+              <input name="location" type="text" value={form.location} onChange={handleChange} required disabled={loading} className="w-full bg-white/10 border border-white/20 rounded-lg px-4 py-2.5 text-white placeholder-blue-300 focus:outline-none focus:ring-2 focus:ring-blue-400" placeholder="City, State" />
             </div>
             <div>
               <label className="block text-blue-100 text-sm font-medium mb-1">Phone Number</label>
-              <input
-                name="phone"
-                type="tel"
-                value={form.phone}
-                onChange={handleChange}
-                required
-                disabled={loading}
-                className="w-full bg-white/10 border border-white/20 rounded-lg px-4 py-2.5 text-white placeholder-blue-300 focus:outline-none focus:ring-2 focus:ring-blue-400"
-                placeholder="(555) 123-4567"
-              />
+              <input name="phone" type="tel" value={form.phone} onChange={handleChange} required disabled={loading} className="w-full bg-white/10 border border-white/20 rounded-lg px-4 py-2.5 text-white placeholder-blue-300 focus:outline-none focus:ring-2 focus:ring-blue-400" placeholder="(555) 123-4567" />
             </div>
             <div>
               <label className="block text-blue-100 text-sm font-medium mb-1">Email</label>
-              <input
-                name="email"
-                type="email"
-                value={form.email}
-                onChange={handleChange}
-                required
-                disabled={loading}
-                className="w-full bg-white/10 border border-white/20 rounded-lg px-4 py-2.5 text-white placeholder-blue-300 focus:outline-none focus:ring-2 focus:ring-blue-400"
-                placeholder="you@example.com"
-              />
+              <input name="email" type="email" value={form.email} onChange={handleChange} required disabled={loading} className="w-full bg-white/10 border border-white/20 rounded-lg px-4 py-2.5 text-white placeholder-blue-300 focus:outline-none focus:ring-2 focus:ring-blue-400" placeholder="you@example.com" />
             </div>
             <div>
               <label className="block text-blue-100 text-sm font-medium mb-1">Password</label>
-              <input
-                name="password"
-                type="password"
-                value={form.password}
-                onChange={handleChange}
-                required
-                minLength={6}
-                disabled={loading}
-                className="w-full bg-white/10 border border-white/20 rounded-lg px-4 py-2.5 text-white placeholder-blue-300 focus:outline-none focus:ring-2 focus:ring-blue-400"
-                placeholder="At least 6 characters"
-              />
+              <input name="password" type="password" value={form.password} onChange={handleChange} required minLength={6} disabled={loading} className="w-full bg-white/10 border border-white/20 rounded-lg px-4 py-2.5 text-white placeholder-blue-300 focus:outline-none focus:ring-2 focus:ring-blue-400" placeholder="At least 6 characters" />
             </div>
             <div>
               <label className="block text-blue-100 text-sm font-medium mb-1">Confirm Password</label>
-              <input
-                name="confirmPassword"
-                type="password"
-                value={form.confirmPassword}
-                onChange={handleChange}
-                required
-                disabled={loading}
-                className="w-full bg-white/10 border border-white/20 rounded-lg px-4 py-2.5 text-white placeholder-blue-300 focus:outline-none focus:ring-2 focus:ring-blue-400"
-                placeholder="Repeat password"
-              />
+              <input name="confirmPassword" type="password" value={form.confirmPassword} onChange={handleChange} required disabled={loading} className="w-full bg-white/10 border border-white/20 rounded-lg px-4 py-2.5 text-white placeholder-blue-300 focus:outline-none focus:ring-2 focus:ring-blue-400" placeholder="Repeat password" />
             </div>
 
-            {/* Invitation Code */}
             <div>
-              <label className="block text-blue-100 text-sm font-medium mb-1">
-                Invitation Code <span className="text-blue-300/70 font-normal">(optional)</span>
-              </label>
+              <label className="block text-blue-100 text-sm font-medium mb-1">Invitation Code <span className="text-blue-300/70 font-normal">(optional)</span></label>
               <div className="flex gap-2">
-                <input
-                  name="inviteCode"
-                  type="text"
-                  value={form.inviteCode}
-                  onChange={handleChange}
-                  disabled={loading}
-                  className={`flex-1 bg-white/10 border rounded-lg px-4 py-2.5 text-white placeholder-blue-300 focus:outline-none focus:ring-2 focus:ring-blue-400 uppercase tracking-wider ${
-                    inviteStatus === 'valid'
-                      ? 'border-green-400/60'
-                      : inviteStatus === 'invalid'
-                      ? 'border-red-400/60'
-                      : 'border-white/20'
-                  }`}
-                  placeholder="Enter your one-time Fixlo code"
-                  autoComplete="off"
-                />
-                {form.inviteCode.trim() && inviteStatus !== 'valid' && (
-                  <button
-                    type="button"
-                    onClick={handleValidateInviteCode}
-                    disabled={inviteValidating || loading}
-                    className="px-4 py-2.5 bg-blue-600 hover:bg-blue-500 text-white text-sm font-semibold rounded-lg transition-colors disabled:opacity-60 whitespace-nowrap"
-                  >
-                    {inviteValidating ? '…' : 'Apply'}
-                  </button>
-                )}
+                <input name="inviteCode" type="text" value={form.inviteCode} onChange={handleChange} disabled={loading} className={`flex-1 bg-white/10 border rounded-lg px-4 py-2.5 text-white placeholder-blue-300 focus:outline-none focus:ring-2 focus:ring-blue-400 uppercase tracking-wider ${inviteStatus === 'valid' ? 'border-green-400/60' : inviteStatus === 'invalid' ? 'border-red-400/60' : 'border-white/20'}`} placeholder="Enter your one-time Fixlo code" autoComplete="off" />
+                {form.inviteCode.trim() && inviteStatus !== 'valid' && <button type="button" onClick={handleValidateInviteCode} disabled={inviteValidating || loading} className="px-4 py-2.5 bg-blue-600 hover:bg-blue-500 text-white text-sm font-semibold rounded-lg transition-colors disabled:opacity-60 whitespace-nowrap">{inviteValidating ? '…' : 'Apply'}</button>}
               </div>
-              {inviteStatus === 'valid' && (
-                <p className="mt-1.5 text-green-400 text-xs font-medium">
-                  ✓ Invitation code accepted.
-                </p>
-              )}
-              {inviteStatus === 'invalid' && (
-                <p className="mt-1.5 text-red-400 text-xs">
-                  This invitation code is invalid, expired, or already used.
-                </p>
-              )}
-              {!inviteStatus && (
-                <p className="mt-1.5 text-blue-300/60 text-xs">
-                  Have an invitation code? Enter it here for special member benefits.
-                </p>
-              )}
+              {inviteStatus === 'valid' && <p className="mt-1.5 text-green-400 text-xs font-medium">✓ Invitation code accepted.</p>}
+              {inviteStatus === 'invalid' && <p className="mt-1.5 text-red-400 text-xs">This invitation code is invalid, expired, or already used.</p>}
+              {!inviteStatus && <p className="mt-1.5 text-blue-300/60 text-xs">Have an invitation code? Enter it here for special member benefits.</p>}
             </div>
 
             <div className="bg-white/5 border border-white/10 rounded-lg p-3">
               <label className="flex items-start gap-3 cursor-pointer">
-                <input
-                  type="checkbox"
-                  checked={smsOptIn}
-                  onChange={e => setSmsOptIn(e.target.checked)}
-                  className="mt-0.5 h-4 w-4 rounded border-white/30 bg-white/10 accent-blue-500 cursor-pointer flex-shrink-0"
-                />
-                <span className="text-blue-200 text-xs leading-relaxed">
-                  I agree to receive SMS notifications from Fixlo about job leads and account updates. Reply STOP to unsubscribe.
-                </span>
+                <input type="checkbox" checked={smsOptIn} onChange={(event) => setSmsOptIn(event.target.checked)} className="mt-0.5 h-4 w-4 rounded border-white/30 bg-white/10 accent-blue-500 cursor-pointer flex-shrink-0" />
+                <span className="text-blue-200 text-xs leading-relaxed">I agree to receive SMS notifications from Fixlo about job leads and account updates. Reply STOP to unsubscribe.</span>
               </label>
             </div>
 
-            <button
-              type="submit"
-              disabled={loading}
-              className="w-full bg-blue-500 hover:bg-blue-400 text-white font-bold py-3 rounded-xl transition-colors disabled:opacity-60 mt-2"
-            >
-              {loading ? 'Creating Account…' : 'Create Pro Account'}
+            <button type="submit" disabled={loading} className="w-full bg-blue-500 hover:bg-blue-400 text-white font-bold py-3 rounded-xl transition-colors disabled:opacity-60 mt-2">
+              {loading ? 'Opening Secure Checkout…' : 'Create Pro Account & Continue to Payment'}
             </button>
           </form>
 
           <div className="mt-6 text-center">
-            <p className="text-blue-200 text-sm">
-              Already have an account?{' '}
-              <Link to="/pros/login" className="text-blue-400 hover:text-blue-300 font-semibold">
-                Sign In
-              </Link>
-            </p>
+            <p className="text-blue-200 text-sm">Already have an account? <Link to="/pros/login" className="text-blue-400 hover:text-blue-300 font-semibold">Sign In</Link></p>
           </div>
 
           <div className="mt-4 text-center">
-            <p className="text-blue-300/60 text-xs">
-              By signing up you agree to our{' '}
-              <Link to="/terms" className="underline hover:text-blue-200">Terms of Service</Link>
-            </p>
+            <p className="text-blue-300/60 text-xs">By signing up you agree to our <Link to="/terms" className="underline hover:text-blue-200">Terms of Service</Link></p>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- Updates `/signup/pro` so a successful Pro account creation immediately creates a Stripe subscription Checkout Session.
- Redirects the new Pro to Stripe using the returned secure `sessionUrl`.
- Keeps invitation-code handling, authentication, SMS consent, and existing account creation behavior.
- Sends the existing Pro plan (`tier: PRO`, `plan: pro`) to the current `/api/stripe/create-checkout-session` backend route.
- Preserves the dashboard redirect only for accounts that do not require a subscription.

## User flow
1. Pro completes the signup form.
2. Fixlo creates the Pro account and signs the user in.
3. Fixlo creates the Stripe Checkout Session.
4. The browser redirects to Stripe for payment.
5. Stripe returns to the existing success or cancel pages.

## Safety
- No backend Stripe pricing, webhook, authentication, or subscription logic changed.
- No Stripe secret keys are exposed to the frontend.
- Checkout continues using the existing server-side Stripe integration and configured live price IDs.